### PR TITLE
fix: resolve clipboard parser lint warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,10 +62,12 @@ export default [
 				HTMLAnchorElement: "readonly",
 				HTMLSpanElement: "readonly",
 				HTMLHeadingElement: "readonly",
-				HTMLParagraphElement: "readonly",
-				HTMLUListElement: "readonly",
-				// File API
-				File: "readonly",
+                                HTMLParagraphElement: "readonly",
+                                HTMLUListElement: "readonly",
+                                EventTarget: "readonly",
+                                ClipboardEvent: "readonly",
+                                // File API
+                                File: "readonly",
 				FileList: "readonly",
 				FileReader: "readonly",
 				// React

--- a/src/utils/__tests__/clipboardImport.test.ts
+++ b/src/utils/__tests__/clipboardImport.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { parseClipboardData, parseClipboardLine } from "../clipboardImport";
+
+describe("clipboardImport", () => {
+        it("parses a line with sale tag", () => {
+                const result = parseClipboardLine("AEROVIBE 20000 - 1000 SALE");
+
+                expect(result).toEqual({
+                        name: "AEROVIBE 20000",
+                        price: 1000,
+                        designType: "sale",
+                        hasDiscount: true,
+                });
+        });
+
+        it("parses a line without tag", () => {
+                const result = parseClipboardLine("ROQY L 20000 - 1 900");
+
+                expect(result).toEqual({
+                        name: "ROQY L 20000",
+                        price: 1900,
+                });
+        });
+
+        it("collects failed lines during bulk parse", () => {
+                const input = "INFLAVE ZERO 2200 - 990\ninvalid line";
+                const { items, failedLines } = parseClipboardData(input);
+
+                expect(items).toEqual([
+                        {
+                                name: "INFLAVE ZERO 2200",
+                                price: 990,
+                        },
+                ]);
+                expect(failedLines).toEqual(["invalid line"]);
+        });
+});

--- a/src/utils/clipboardImport.ts
+++ b/src/utils/clipboardImport.ts
@@ -1,0 +1,152 @@
+import type { Item } from "@/store/priceTagsStore";
+
+export interface ParsedClipboardItem {
+        name: string;
+        price: number;
+        designType?: Item["designType"];
+        hasDiscount?: boolean;
+}
+
+export interface ClipboardParseResult {
+        items: ParsedClipboardItem[];
+        failedLines: string[];
+}
+
+const DESIGN_TAG_MAP: Record<
+        string,
+        { designType?: Item["designType"]; hasDiscount?: boolean }
+> = {
+        sale: { designType: "sale", hasDiscount: true },
+        new: { designType: "new" },
+        default: { designType: "default" },
+};
+
+const DASH_REGEXP = /[-–—]/;
+
+const isEditableTarget = (target: EventTarget | null): boolean => {
+        if (!target || !(target instanceof HTMLElement)) {
+                return false;
+        }
+
+        const tagName = target.tagName;
+
+        if (tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT") {
+                return true;
+        }
+
+        return target.isContentEditable;
+};
+
+const sanitizePrice = (rawPrice: string): number | null => {
+        const normalized = rawPrice.replace(/[\s₽руб.,]+$/iu, "");
+        const digitsOnly = normalized.replace(/[^\d.,]/g, "").replace(/,/g, ".");
+
+        if (!digitsOnly) {
+                return null;
+        }
+
+        const price = Number.parseFloat(digitsOnly);
+
+        if (!Number.isFinite(price) || price <= 0) {
+                return null;
+        }
+
+        return Math.round(price);
+};
+
+export const parseClipboardLine = (line: string): ParsedClipboardItem | null => {
+        const trimmedLine = line.trim();
+
+        if (!trimmedLine) {
+                return null;
+        }
+
+        const dashIndex = trimmedLine.search(DASH_REGEXP);
+
+        if (dashIndex === -1) {
+                return null;
+        }
+
+        const rawName = trimmedLine.slice(0, dashIndex).trim();
+        let remainder = trimmedLine.slice(dashIndex + 1).trim();
+
+        if (!rawName || !remainder) {
+                return null;
+        }
+
+        const tagMatch = remainder.match(/\b([A-Za-zА-Яа-яЁё]+)\b$/u);
+
+        let tag: string | undefined;
+
+        if (tagMatch) {
+                const candidate = tagMatch[1]?.toLowerCase();
+
+                if (candidate && DESIGN_TAG_MAP[candidate]) {
+                        tag = candidate;
+                        remainder = remainder.slice(0, tagMatch.index).trim();
+                }
+        }
+
+        const price = sanitizePrice(remainder);
+
+        if (price === null) {
+                return null;
+        }
+
+        const normalizedName = rawName.replace(/\s+/g, " ");
+
+        const parsedItem: ParsedClipboardItem = {
+                name: normalizedName,
+                price,
+        };
+
+        if (tag) {
+                const mapped = DESIGN_TAG_MAP[tag];
+
+                if (mapped.designType) {
+                        parsedItem.designType = mapped.designType;
+                }
+
+                if (mapped.hasDiscount !== undefined) {
+                        parsedItem.hasDiscount = mapped.hasDiscount;
+                }
+        }
+
+        return parsedItem;
+};
+
+export const parseClipboardData = (text: string): ClipboardParseResult => {
+        const lines = text.split(/\r?\n/);
+        const items: ParsedClipboardItem[] = [];
+        const failedLines: string[] = [];
+
+        for (const rawLine of lines) {
+                const parsed = parseClipboardLine(rawLine);
+
+                if (parsed) {
+                        items.push(parsed);
+                } else if (rawLine.trim()) {
+                        failedLines.push(rawLine.trim());
+                }
+        }
+
+        return { items, failedLines };
+};
+
+export const shouldHandlePasteEvent = (event: ClipboardEvent): boolean => {
+        if (!event.clipboardData) {
+                return false;
+        }
+
+        if (isEditableTarget(event.target)) {
+                return false;
+        }
+
+        const text = event.clipboardData.getData("text/plain");
+
+        if (!text) {
+                return false;
+        }
+
+        return /[-–—]/.test(text);
+};


### PR DESCRIPTION
## Summary
- update the clipboard price sanitizer regex to avoid unnecessary escaping flagged by ESLint
- declare DOM clipboard globals so the parser and page handlers pass no-undef checks

## Testing
- pnpm run build *(fails: Empty token error from /api/bot during data collection)*

------
https://chatgpt.com/codex/tasks/task_e_68d7cf880bd883329195d5ba7a36c076